### PR TITLE
feat(strapi): add nginx client-max-body-size annotation to ingress

### DIFF
--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
+    nginx.org/client-max-body-size: '100m'
 spec:
   tls:
     - hosts:

--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -8,7 +8,8 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
-    nginx.org/client-max-body-size: '100m'
+    nginx.org/client-max-body-size: '0'
+    nginx.org/location-snippets: 'proxy_request_buffering off;'
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
## Summary
- Adds `nginx.org/client-max-body-size: 0` annotation to the strapi ingress in the base kustomize config
- Ensures the annotation persists across all clusters and deployments instead of being set manually via kubectl

Made with [Cursor](https://cursor.com)